### PR TITLE
Allow for dts paths to be specified.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,18 @@ export default {
   plugins: [dts()],
 }
 ```
+
+#### Custom `d.ts` locations
+
+By default, the output `d.ts` files will be based on the `main` and `module` entries of `package.json`. To use alternate paths, supply the `cjsModulePath` and `esModulePath` arguments to `dts()`.
+
+```ts
+import dts from 'vite-dts'
+
+export default {
+  plugins: [dts({
+    cjsModulePath: 'dist/foo/bar.umd.d.ts',
+    esModulePath: 'dist/foo/bar.es.d.ts'
+  })],
+}
+```

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -3,7 +3,15 @@ import loadJSON from 'load-json-file'
 import * as path from 'path'
 import * as fs from 'fs'
 
-export default function dts(): Plugin {
+export interface DtsPluginArgs {
+  cjsModulePath?: string;
+  esModulePath?: string;
+}
+
+export default function dts({
+  cjsModulePath,
+  esModulePath
+}: DtsPluginArgs = {}): Plugin {
   return {
     name: 'vite:dts',
     apply: 'build',
@@ -47,8 +55,8 @@ export default function dts(): Plugin {
         `export * from "${posixEntryImportPath}"` +
         (hasDefaultExport ? `\nexport {default} from "${posixEntryImportPath}"` : ``)
 
-      const cjsModulePath = path.relative(outDir, pkg.main)
-      const esModulePath = path.relative(outDir, pkg.module)
+      cjsModulePath = cjsModulePath ?? path.relative(outDir, pkg.main)
+      esModulePath = esModulePath ?? path.relative(outDir, pkg.module)
 
       this.generateBundle = function ({ entryFileNames }) {
         if (entryFileNames == cjsModulePath) {


### PR DESCRIPTION
I'm working on a project that bundles multiple libraries from the same package, but `dts` currently uses `main` and `module` exclusively for determining where to output files. This PR adds the ability to pass specific paths for output to be used with [subpath exports](https://nodejs.org/api/packages.html#subpath-exports).