### PR TITLE
enhancement: allow for dts paths to use exports field.

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -3,13 +3,23 @@
   "version": "1.0.0",
   "main": "dist/vite-lib.cjs.js",
   "module": "dist/vite-lib.es.js",
+  "exports": {
+    ".": {
+      "import": "./dist/vite-lib.es.js",
+      "require": "./dist/vite-lib.cjs.js"
+    },
+    "./nested/": {
+      "import": "./dist/nested/vite-lib.es.js",
+      "require": "./dist/nested/vite-lib.cjs.js"
+    }
+  },
   "files": [
     "dist",
     "src"
   ],
   "scripts": {
     "dev": "vite",
-    "build": "vite build"
+    "build": "vite build && vite build -c vite.config.nested.js"
   },
   "devDependencies": {
     "@types/react": "^17.0.11",

--- a/demo/src/nested.tsx
+++ b/demo/src/nested.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react'
+import { styleKeys } from './style-keys'
+
+export interface Props extends React.CSSProperties {
+  as?: string | React.ComponentType<{ style?: React.CSSProperties }>
+  children?: any
+}
+
+export function Box({ as: View = 'div', children, ...props }: Props) {
+  type Prop = keyof typeof props
+
+  const style: any = {}
+  for (const key in props) {
+    if (styleKeys.includes(key)) {
+      style[key] = props[key as Prop]
+      delete props[key as Prop]
+    }
+  }
+
+  return (
+    <View {...props} style={style}>
+      Nested
+      {children}
+    </View>
+  )
+}

--- a/demo/vite.config.nested.js
+++ b/demo/vite.config.nested.js
@@ -1,0 +1,27 @@
+// @ts-check
+import { defineConfig } from 'vite'
+import dts from 'vite-dts'
+
+export default defineConfig({
+  build: {
+    outDir: 'dist/nested',
+    lib: {
+      entry: 'src/nested.tsx',
+      formats: ['es', 'cjs']
+    },
+    rollupOptions: {
+      external: ['react'],
+      output: {
+        // Since we publish our ./src folder, there's no point
+        // in bloating sourcemaps with another copy of it.
+        sourcemapExcludeSources: true,
+      },
+    },
+    sourcemap: true,
+    // Reduce bloat from legacy polyfills.
+    target: 'esnext',
+    // Leave minification up to applications.
+    minify: false,
+  },
+  plugins: [dts()],
+})

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -50,17 +50,16 @@ export default function dts(): Plugin {
       const cjsModulePath = path.relative(outDir, pkg.main)
       const esModulePath = path.relative(outDir, pkg.module)
 
+      const exports = Object.keys(pkg.exports || {})
+      const requirePaths = exports.map(k => path.relative(outDir, pkg.exports[k].require)).filter(p => !!p)
+      const importPaths = exports.map(k => path.relative(outDir, pkg.exports[k].import)).filter(p => !!p)
+
       this.generateBundle = function ({ entryFileNames }) {
-        if (entryFileNames == cjsModulePath) {
+        const name = `${entryFileNames}`;
+        if (requirePaths.includes(name) || importPaths.includes(name) || name == cjsModulePath || name == esModulePath) {
           this.emitFile({
             type: 'asset',
-            fileName: cjsModulePath.replace(/\.js$/, '.d.ts'),
-            source: dtsModule,
-          })
-        } else if (entryFileNames == esModulePath) {
-          this.emitFile({
-            type: 'asset',
-            fileName: esModulePath.replace(/\.js$/, '.d.ts'),
+            fileName: name.replace(/\.js$/, '.d.ts'),
             source: dtsModule,
           })
         }


### PR DESCRIPTION
I'm working on a project that bundles multiple libraries from the same package, but dts currently uses `main` and `module` exclusively for determining where to output files. This PR adds the ability to parse [subpath exports](https://nodejs.org/api/packages.html#subpath-exports).