### PR TITLE
feat: allow using .mjs extension

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -60,7 +60,10 @@ export default function dts(): Plugin {
         } else if (entryFileNames == esModulePath) {
           this.emitFile({
             type: 'asset',
-            fileName: esModulePath.replace(/\.js$/, '.d.ts'),
+            fileName:
+              path.extname(esModulePath) == '.mjs'
+                ? esModulePath + '.d.ts'
+                : esModulePath.replace(/\.js$/, '.d.ts'),
             source: dtsModule,
           })
         }


### PR DESCRIPTION
If you define a file in the `module` field which has a `.mjs` extension, this plugin currently overwrites it with the type definitions. With this change, it instead correctly writes to `.mjs.d.ts`